### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ beaker wasm new counter
 
 ### Deploy contract on LocalOsmosis
 
-Make sure LocalOsmosis has been started (see: https://github.com/osmosis-labs/LocalOsmosis).
+Make sure LocalOsmosis has been started (see: https://github.com/osmosis-labs/LocalOsmosis) or simply use the official installer and select option 3:
+
+```sh
+curl -sL https://get.osmosis.zone/install > i.py && python3 i.py
+```
 
 After that, `counter` contract can be deployed (build + store-code + instantiate) using the following command:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 CosmWasm development tooling.
 ![crates.io](https://img.shields.io/crates/v/beaker.svg)
 
-Beaker makes it easy to scaffold a new cosmwasm app, with all of the dependencies for osmosis hooked up, and a sample front-end at the ready.
+[Beaker](https://github.com/osmosis-labs/beaker) makes it easy to scaffold a new cosmwasm app, with all of the dependencies for osmosis hooked up, and a sample front-end at the ready.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ await contract.counter.query({ "get_count": {}})
 
 You can remove `contract` and/or `account` namespace by changing config.
 
-```toml
+```
 # Beaker.toml
 
 [console]


### PR DESCRIPTION
- Letting people know they can run localOsmosis with a single command to save them some valuable time.
- Adding Added link to Beaker name so that a link is accessible to from the official docs. This readme is copied automatically to the official docs via CI (https://docs.osmosis.zone/developing/tools/beaker.html#getting-started)
- Removed toml formatting since it's not supported on official docs for some reason  
as seen here:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/13665117/174342381-155e4e35-bd6a-454c-849d-e5371ddc717c.png">
