### PR TITLE
Store code proposal file (yaml/toml)

### DIFF
--- a/docs/commands/beaker_wasm.md
+++ b/docs/commands/beaker_wasm.md
@@ -90,6 +90,8 @@ Arguments:
 
 * `-r/--raw <raw>`: Raw json string to use as instantiate msg
 
+* `--admin <admin>`: Specifying admin required for contract migration. Use "signer" for setting tx signer as admin. Use bech32 address (eg. "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks") for custom admin
+
 * `-f/--funds <funds>`: Funds to send to instantiated contract
 
 * `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
@@ -123,6 +125,8 @@ Arguments:
 * `-l/--label <label>`: Label for the instantiated contract for later reference (default: `default`)
 
 * `-r/--raw <raw>`: Raw json string to use as instantiate msg
+
+* `--admin <admin>`: Specifying admin required for contract migration. Use "signer" for setting tx signer as admin. Use bech32 address (eg. "osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks") for custom admin
 
 * `-f/--funds <funds>`: Funds to send to instantiated contract
 

--- a/docs/commands/beaker_wasm_proposal.md
+++ b/docs/commands/beaker_wasm_proposal.md
@@ -20,11 +20,19 @@ Arguments:
 
 * ` <contract-name>`Name of the contract to store
 
-* `--title <title>`: Proposal title
+* `-p/--proposal <proposal>`: Path to proposal file, could be either yaml / toml format
 
-* `-d/--description <description>`: Proposal decsription
+* `--title <title>`: Proposal title (default: ``)
+
+* `--description <description>`: Proposal decsription (default: ``)
 
 * `--deposit <deposit>`: Proposal deposit to activate voting
+
+* `--repo <repo>`: Public repository of the code (default: ``)
+
+* `--rust-flags <rust-flags>`: RUST_FLAGS that passed while compiling to wasm If building with Beaker, it's usually "-C link-arg=-s"
+
+* `--optimizer <optimizer>`: Type and version of the [optimizer](https://github.com/CosmWasm/rust-optimizer), either: rust-optimizer:<version> or workspace-optimizer:<version>. Beaker use workspace-optimizer, the version, if not manually configured, can be found in `wasm` config doc
 
 * `-n/--network <network>`: Name of the network to broadcast transaction to, the actual endpoint / chain-id are defined in config (default: `local`)
 

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -23,10 +23,12 @@ prost = "0.10.3"
 regex = "1.5.6"
 serde = "1.0.137"
 serde_json = "1.0.81"
+serde_yaml = "0.8"
 tokio = {version = "1.18.2", features = ["full"]}
 
 [dev_dependencies]
 assert_fs = "1.0.7"
 cargo_toml = "0.11.5"
 predicates = "2.1.1"
+pretty_assertions = "1.2.1"
 serial_test = "0.6.0"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -25,6 +25,7 @@ serde = "1.0.137"
 serde_json = "1.0.81"
 serde_yaml = "0.8"
 tokio = {version = "1.18.2", features = ["full"]}
+toml = "0.5.9"
 
 [dev_dependencies]
 assert_fs = "1.0.7"

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -26,6 +26,7 @@ pub struct Cli {
 // === APP DEFINITION ===
 // Could potentially move all this to macro
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Commands {
     #[clap(flatten)]
     Workspace(WorkspaceCmd),

--- a/packages/cli/src/modules/wasm/proposal/entrypoint.rs
+++ b/packages/cli/src/modules/wasm/proposal/entrypoint.rs
@@ -1,6 +1,5 @@
-use std::path::PathBuf;
-
 use clap::Subcommand;
+use std::path::PathBuf;
 
 use crate::{
     framework::Context,
@@ -70,8 +69,15 @@ pub fn execute<'a, Ctx: Context<'a, WasmConfig>>(
         } => {
             let proposal = if let Some(p) = proposal {
                 let proposal_str = std::fs::read_to_string(p)?;
-                let store_code_proposal: StoreCodeProposal =
-                    serde_yaml::from_str(proposal_str.as_str())?;
+                let extention_error_msg = "Extension must be one of `yaml`, `yml` or `toml`";
+                let ext = p.extension().expect(extention_error_msg);
+                let store_code_proposal: StoreCodeProposal = if ext == "yaml" || ext == "yml" {
+                    serde_yaml::from_str(proposal_str.as_str())?
+                } else if ext == "toml" {
+                    toml::from_str(proposal_str.as_str())?
+                } else {
+                    panic!("{}", extention_error_msg);
+                };
                 Some(store_code_proposal)
             } else {
                 None

--- a/packages/cli/src/modules/wasm/proposal/mod.rs
+++ b/packages/cli/src/modules/wasm/proposal/mod.rs
@@ -1,2 +1,3 @@
 pub mod entrypoint;
 pub mod ops;
+pub mod proposal_struct;

--- a/packages/cli/src/modules/wasm/proposal/proposal_struct.rs
+++ b/packages/cli/src/modules/wasm/proposal/proposal_struct.rs
@@ -66,6 +66,25 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
+    fn proposal_fixture() -> StoreCodeProposal {
+        StoreCodeProposal {
+            title: "Proposal to allow DappName to be enabled in Osmosis".to_string(),
+            description: trim_indent(
+                r#"
+            A lengthy proposal description
+            goes here
+            we expect this to be many lines...
+            "#,
+            ),
+            deposit: Some("1000uosmo".to_string()),
+            code: Code {
+                repo: "https://github.com/osmosis-labs/beaker/templates/project".to_string(),
+                rust_flags: Some("-C link-arg=-s".to_string()),
+                optimizer: Some("workspace-optimizer:0.12.6".to_string()),
+            },
+        }
+    }
+
     #[test]
     fn store_code_proposal_yaml() {
         let yaml = &trim_indent(
@@ -85,24 +104,32 @@ mod tests {
 
         let prop: StoreCodeProposal = serde_yaml::from_str(yaml).unwrap();
 
-        assert_eq!(
-            prop,
-            StoreCodeProposal {
-                title: "Proposal to allow DappName to be enabled in Osmosis".to_string(),
-                description: trim_indent(
-                    r#"
-                    A lengthy proposal description
-                    goes here
-                    we expect this to be many lines...
-                    "#
-                ),
-                deposit: Some("1000uosmo".to_string()),
-                code: Code {
-                    repo: "https://github.com/osmosis-labs/beaker/templates/project".to_string(),
-                    rust_flags: Some("-C link-arg=-s".to_string()),
-                    optimizer: Some("workspace-optimizer:0.12.6".to_string()),
-                }
-            }
+        assert_eq!(prop, proposal_fixture());
+    }
+
+    #[test]
+    fn store_code_proposal_toml() {
+        let toml_str = &trim_indent(
+            r#"
+                title = "Proposal to allow DappName to be enabled in Osmosis"
+
+                description = '''
+                A lengthy proposal description
+                goes here
+                we expect this to be many lines...
+                '''
+
+                deposit = "1000uosmo"
+
+                [code]
+                repo = "https://github.com/osmosis-labs/beaker/templates/project"
+                rust_flags = "-C link-arg=-s"
+                optimizer = "workspace-optimizer:0.12.6"
+            "#,
         );
+
+        let prop: StoreCodeProposal = toml::from_str(toml_str).unwrap();
+
+        assert_eq!(prop, proposal_fixture());
     }
 }

--- a/packages/cli/src/modules/wasm/proposal/proposal_struct.rs
+++ b/packages/cli/src/modules/wasm/proposal/proposal_struct.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+struct Code {
+    repo: String,
+    rust_flags: Option<String>,
+    optimizer: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct StoreCodeProposal {
+    title: String,
+    description: String,
+    code: Code,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::support::string::trim_indent;
+
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn store_code_proposal_yaml() {
+        let yaml = &trim_indent(
+            r#"
+                title: Proposal to allow DappName to be enabled in Osmosis
+                description: |
+                            A lengthy proposal description
+                            goes here
+                            we expect this to be many lines...
+                code:
+                    repo: https://github.com/osmosis-labs/beaker/templates/project
+                    rust_flags: -C link-arg=-s
+                    optimizer: workspace-optimizer:0.12.6
+            "#,
+        );
+
+        let prop: StoreCodeProposal = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(
+            prop,
+            StoreCodeProposal {
+                title: "Proposal to allow DappName to be enabled in Osmosis".to_string(),
+                description: trim_indent(
+                    r#"
+                    A lengthy proposal description
+                    goes here
+                    we expect this to be many lines...
+                    "#
+                ),
+                code: Code {
+                    repo: "https://github.com/osmosis-labs/beaker/templates/project".to_string(),
+                    rust_flags: Some("-C link-arg=-s".to_string()),
+                    optimizer: Some("workspace-optimizer:0.12.6".to_string()),
+                }
+            }
+        );
+    }
+}

--- a/packages/cli/src/modules/wasm/proposal/proposal_struct.rs
+++ b/packages/cli/src/modules/wasm/proposal/proposal_struct.rs
@@ -49,10 +49,11 @@ impl StoreCodeProposal {
     pub fn description_with_metadata(&self) -> Result<String> {
         Ok(vec![
             self.description.trim(),
-            "\n",
-            "[METADATA]",
-            serde_yaml::to_string::<Code>(&self.code)?.as_str(),
-            "[/METADATA]",
+            "",
+            "---",
+            "",
+            "[metadata]",
+            toml::to_string::<Code>(&self.code)?.as_str().trim(),
         ]
         .join("\n"))
     }

--- a/packages/cli/src/support/mod.rs
+++ b/packages/cli/src/support/mod.rs
@@ -7,5 +7,6 @@ pub mod ops_response;
 pub mod proto;
 pub mod signer;
 pub mod state;
+pub mod string;
 pub mod template;
 pub mod wasm;

--- a/packages/cli/src/support/ops_response.rs
+++ b/packages/cli/src/support/ops_response.rs
@@ -16,6 +16,35 @@ pub trait OpResponseDisplay {
 }
 
 #[macro_export]
+macro_rules! format_single_val {
+    (@last, $ident:ident, $value:expr) => {
+        vec![
+            format!("    └── {}: {}", stringify!($ident), $value),
+            "".to_string(),
+        ]
+    };
+    (@inbetween, $ident:ident, $value:expr) => {{
+        let lines = format!("{}", $value);
+        let lines = lines.split("\n");
+        if lines.clone().count() > 1 {
+            vec![
+                vec![
+                    format!("    ├── {}:", stringify!($ident)),
+                    "    │".to_string(),
+                ],
+                lines
+                    .map(|s| format!("    │     {}", s))
+                    .collect::<Vec<String>>(),
+                vec!["    │".to_string()],
+            ]
+            .concat()
+        } else {
+            vec![format!("    ├── {}: {}", stringify!($ident), $value)]
+        }
+    }};
+}
+
+#[macro_export]
 macro_rules! attrs_format {
     ($container:ident | $attr:ident) => {
         vec![format!("    └── {}: {}", stringify!($attr), $container.$attr)]
@@ -31,11 +60,11 @@ macro_rules! attrs_format {
 #[macro_export]
 macro_rules! vars_format {
     ($attr:ident) => {
-        vec![format!("    └── {}: {}", stringify!($attr), $attr), "".to_string()]
+        $crate::format_single_val!(@last, $attr, $attr)
     };
     ($fst:ident, $($attr:ident),+) => {
         vec![
-           vec![format!("    ├── {}: {}", stringify!($fst), $fst)],
+            $crate::format_single_val!(@inbetween, $fst, $fst),
            vars_format!($($attr),+ )
         ].concat()
     };

--- a/packages/cli/src/support/string.rs
+++ b/packages/cli/src/support/string.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 pub fn trim_indent(s: &str) -> String {
     let it = s.split('\n');
     let first = it.clone().find(|s| !s.is_empty());

--- a/packages/cli/src/support/string.rs
+++ b/packages/cli/src/support/string.rs
@@ -1,0 +1,15 @@
+pub fn trim_indent(s: &str) -> String {
+    let it = s.split('\n');
+    let first = it.clone().find(|s| !s.is_empty());
+    if let Some(f) = first {
+        let space_count = f.chars().take_while(|c| c == &' ').count();
+        let pat = " ".repeat(space_count);
+
+        it.map(|s| s.trim_start_matches(pat.as_str()))
+            .skip_while(|s| s.is_empty())
+            .collect::<Vec<&str>>()
+            .join("\n")
+    } else {
+        s.to_string()
+    }
+}


### PR DESCRIPTION
closes #48


- support proposal file with metatdata required for verification
- append the metadata in the proposal description in a serializable format
- share the same options in the command and proposal file
- pretty print multiline response
- support toml and yaml as input file
- make deposit optional (#49)


## example

### with `toml`

`proposal.toml`
```toml
title = "Proposal to allow DappName to be enabled in Osmosis"

description = '''
A lengthy proposal description
goes here
we expect this to be many lines...
'''

[code]
repo = "https://github.com/osmosis-labs/beaker/templates/project"
rust_flags = "-C link-arg=-s"
optimizer = "workspace-optimizer:0.12.6"

```

### with `yaml`

`proposal.yaml` or `proposal.yml`
```yml
title: Proposal to allow DappName to be enabled in Osmosis
description: |
    A lengthy proposal description
    goes here
    so many lines...
deposit: 1000uosmo
code:
    repo: https://github.com/osmosis-labs/beaker/templates/project
    rust_flags: -C link-arg=-s
    optimizer: workspace-optimizer:0.12.6
```

```sh
$ beaker wasm proposal store-code counter --signer-account test1 --proposal proposal.yaml # `.yml` works as well
```
### Result

```sh
$ beaker wasm proposal query store-code counter
```

```

  Proposal found!
    +
    ├── proposal_id: 1
    ├── title: Proposal to allow DappName to be enabled in Osmosis
    ├── description:
    │
    │     A lengthy proposal description
    │     goes here
    │     we expect this to be many lines...
    │     
    │     ---
    │     
    │     [metadata]
    │     repo = "https://github.com/osmosis-labs/beaker/templates/project"
    │     rust_flags = "-C link-arg=-s"
    │     optimizer = "workspace-optimizer:0.12.6"
    │
    ├── run_as: osmo1cyyzpxplxdzkeea7kwsydadg87357qnahakaks
    ├── total_deposit:  (min_deposit: 10000000uosmo)
    └── status: DepositPeriod


  Tally Result
    +
    ├── yes: 0
    ├── no: 0
    ├── no_with_veto: 0
    └── abstain: 0


  Time
    +
    ├── submit_time: 2022-07-04T08:58:03Z
    ├── deposit_end_time: 2022-07-06T08:58:03Z
    ├── voting_start_time: –
    └── voting_end_time: –


```

The string below is stored in the proposal description:

```
A lengthy proposal description
goes here
we expect this to be many lines...

---

[metadata]
repo = "https://github.com/osmosis-labs/beaker/templates/project"
rust_flags = "-C link-arg=-s"
optimizer = "workspace-optimizer:0.12.6"
```

Which includes the metadata that structured, deserializable and gives enough information to do #57 on proposal later.

While #48 suggests the `settings` part, I think that should be kept separated and keep this proposal part as primitive for later more sophisticated workflow automation which I believe require more thoughts and not the current focus.