### PR TITLE
Update signer-keyring's description.

### DIFF
--- a/docs/commands/beaker_wasm.md
+++ b/docs/commands/beaker_wasm.md
@@ -68,7 +68,7 @@ Arguments:
 
 * `--signer-account <signer-account>`: Specifies predefined account as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-keyring <signer-keyring>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).
 
 * `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
 
@@ -154,7 +154,7 @@ Arguments:
 
 * `--signer-account <signer-account>`: Specifies predefined account as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-keyring <signer-keyring>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).
 
 * `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
 
@@ -196,7 +196,7 @@ Arguments:
 
 * `--signer-account <signer-account>`: Specifies predefined account as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-keyring <signer-keyring>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).
 
 * `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
 
@@ -234,7 +234,7 @@ Arguments:
 
 * `--signer-account <signer-account>`: Specifies predefined account as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-keyring <signer-keyring>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).
 
 * `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
 
@@ -278,7 +278,7 @@ Arguments:
 
 * `--signer-account <signer-account>`: Specifies predefined account as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-keyring <signer-keyring>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).
 
 * `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
 
@@ -318,7 +318,7 @@ Arguments:
 
 * `--signer-account <signer-account>`: Specifies predefined account as a tx signer
 
-* `--signer-keyring <signer-keyring>`: Specifies private_key as a tx signer (base64 encoded string)
+* `--signer-keyring <signer-keyring>`: Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).
 
 * `--signer-mnemonic <signer-mnemonic>`: Specifies mnemonic as a tx signer
 


### PR DESCRIPTION
Update description for `--signer-keyring`

from: 
Specifies private_key as a tx signer (base64 encoded string)

to: 
Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).