### PR TITLE
Update signer-keyring's description.

### DIFF
--- a/packages/cli/src/support/signer.rs
+++ b/packages/cli/src/support/signer.rs
@@ -18,7 +18,7 @@ pub struct SignerArgs {
     #[clap(long, group = SIGNER_GROUP)]
     pub signer_account: Option<String>,
 
-    /// Specifies private_key as a tx signer (base64 encoded string)
+    /// Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).
     #[clap(long, group = SIGNER_GROUP)]
     pub signer_keyring: Option<String>,
 


### PR DESCRIPTION
Update description for `--signer-keyring`

from: 
Specifies private_key as a tx signer (base64 encoded string)

to: 
Use the OS secure store as backend to securely store your key. To manage them, you can find more information [here](docs/commands/beaker_key.md).