### PR TITLE
Fix typo in beaker cli when executing query

### DIFF
--- a/packages/cli/src/modules/wasm/ops/query.rs
+++ b/packages/cli/src/modules/wasm/ops/query.rs
@@ -80,7 +80,7 @@ pub struct QueryResponse {
 
 impl OpResponseDisplay for QueryResponse {
     fn headline() -> &'static str {
-        "Succesffuly executed query!! 🎉 "
+        "Successfully executed query!! 🎉 "
     }
     fn attrs(&self) -> Vec<String> {
         attrs_format! { self | label, contract_address, data }


### PR DESCRIPTION
Small typo in "successfully" when executing a query:

<img width="632" alt="Screen Shot 2022-09-25 at 5 28 27 PM" src="https://user-images.githubusercontent.com/36896271/192172922-94fb3fee-6e46-43cc-a0c4-53041222ec8e.png">
