### PR TITLE
Default port for testnet is 443

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -23,7 +23,7 @@ rpc_endpoint = 'http://localhost:26657'
 [networks.testnet]
 chain_id = 'osmo-test-4'
 network_variant = 'Shared'
-grpc_endpoint = 'https://grpc-test.osmosis.zone:9090'
+grpc_endpoint = 'https://grpc-test.osmosis.zone:443'
 rpc_endpoint = 'https://rpc-test.osmosis.zone'
 
 [networks.mainnet]


### PR DESCRIPTION
Updating port to 443. I think we they should be the same but I'll follow up with Nicco to discuss. 