### PR TITLE
Adding cw-orchestrator to beaker

### DIFF
--- a/templates/project/contracts/counter/Cargo.toml
+++ b/templates/project/contracts/counter/Cargo.toml
@@ -31,6 +31,8 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+# use interface feature to expose structure for contract orchestration
+interface = ["dep:cw-orch"]
 
 [package.metadata.scripts]
 optimize = """docker run --rm -v "$(pwd)":/code \
@@ -49,5 +51,8 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 
+cw-orch = { version = "0.18.1", optional = true }
+
 [dev-dependencies]
 cw-multi-test = "0.13.2"
+counter = {path = ".", features=["interface"]}

--- a/templates/project/contracts/counter/src/interface.rs
+++ b/templates/project/contracts/counter/src/interface.rs
@@ -1,0 +1,45 @@
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_std::Empty;
+use cw_orch::{interface, prelude::*};
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+pub struct Counter;
+
+impl<Chain: CwEnv> Uploadable for Counter<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(&self) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path("{{crate_name}}")
+            .unwrap()
+    }
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper(&self) -> Box<dyn MockContract<Empty>> {
+        Box::new(ContractWrapper::new_with_empty(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::msg::{ExecuteMsgFns, QueryMsgFns};
+    use cw_orch::anyhow;
+
+    #[test]
+    fn contract_logic() -> anyhow::Result<()> {
+        let mock = Mock::new(&Addr::unchecked("sender"));
+        let contract = Counter::new("project-name", mock);
+        contract.upload()?;
+
+        contract.instantiate(&InstantiateMsg { count: 7 }, None, None)?;
+        assert_eq!(contract.get_count()?.count, 7);
+
+        contract.increment()?;
+        assert_eq!(contract.get_count()?.count, 8);
+
+        Ok(())
+    }
+}

--- a/templates/project/contracts/counter/src/lib.rs
+++ b/templates/project/contracts/counter/src/lib.rs
@@ -6,3 +6,6 @@ pub mod msg;
 pub mod state;
 
 pub use crate::error::ContractError;
+
+#[cfg(feature = "interface")]
+pub mod interface;

--- a/templates/project/contracts/counter/src/msg.rs
+++ b/templates/project/contracts/counter/src/msg.rs
@@ -6,6 +6,7 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
 pub enum ExecuteMsg {
     Increment {},
     Reset { count: i32 },
@@ -13,6 +14,7 @@ pub enum ExecuteMsg {
 
 #[cw_serde]
 #[derive(QueryResponses)]
+#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 pub enum QueryMsg {
     // GetCount returns the current count as a json-encoded number
     #[returns(GetCountResponse)]


### PR DESCRIPTION
This PR aims at adding cw-orchestrator directly into beaker.

We added cw-orch into [the cw-minimal-template](https://github.com/osmosis-labs/cw-minimal-template/pull/1) as well.

You can find the docs for this library here : https://orchestrator.abstract.money/

This library empowers users with their smart-contracts and allows them to script, test and more using a single intuitive syntax and without leaving the Rust programming language.

With this template, cw-orch integration has never been easier. The generated interface is available directly inside the template tests. An example test syntax can be found in the `src/interface.rs` file.

